### PR TITLE
Add support for more queue attributes

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -4,15 +4,12 @@ locals {
       for name, consumer in var.pull_consumers : [
         for topic, subscription in consumer.subscriptions : {
           key = "${name}-${topic}"
-          value = {
+          value = merge(subscription, {
             queue           = name
             labels          = consumer.labels
             service_account = consumer.service_account
             topic           = subscription.topic != null ? subscription.topic : topic
-            project         = subscription.project
-            enable_ordering = subscription.enable_ordering
-            disable_dlq     = subscription.disable_dlq
-          }
+          })
         }
       ]
     ]) :

--- a/subscriptions.tf
+++ b/subscriptions.tf
@@ -2,13 +2,17 @@ module "subscriptions" {
   for_each = local.subscriptions
 
   source  = "cloudchacho/hedwig-subscription/google"
-  version = ">= 3.4, <4"
+  version = ">= 3.5, <4"
 
   queue                   = each.value.queue
   topic                   = each.value.project != null ? "projects/${each.value.project}/topics/hedwig-${each.value.topic}" : module.topics[each.value.topic].name
   enable_message_ordering = each.value.enable_ordering
   iam_service_account     = each.value.service_account
   disable_dlq             = each.value.disable_dlq
+  filter                  = each.value.filter
+  max_delivery_attempts   = each.value.max_delivery_attempts
+  retry_policy            = each.value.retry_policy
+  retain_acked_messages   = each.value.retain_acked_messages
 
   labels = each.value.labels
 }

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,21 @@ variable "pull_consumers" {
 
       # disable dead letter queues. This is useful for firehose subscription using dataflow. Default false.
       disable_dlq = optional(bool, false)
+
+      # The subscription only delivers the messages that match the filter. Pub/Sub automatically acknowledges the messages that don't match the filter. You can filter messages by their attributes. The maximum length of a filter is 256 bytes. After creating the subscription, you can't modify the filter.
+      filter = optional(string)
+
+      # The maximum number of delivery attempts for any message. The value must be between 5 and 100. The number of delivery attempts is defined as 1 + (the sum of number of NACKs and number of times the acknowledgement deadline has been exceeded for the message). A NACK is any call to ModifyAckDeadline with a 0 deadline. Note that client libraries may automatically extend ack_deadlines. This field will be honored on a best effort basis.
+      max_delivery_attempts = optional(number)
+
+      # A policy that specifies how Pub/Sub retries message delivery for this subscription. If not set, the default retry policy is applied. This generally implies that messages will be retried as soon as possible for healthy subscribers. RetryPolicy will be triggered on NACKs or acknowledgement deadline exceeded events for a given message
+      retry_policy = optional(object({
+        minimum_backoff = string
+        maximum_backoff = string
+      }))
+
+      # Indicates whether to retain acknowledged messages. If true, then messages are not expunged from the subscription's backlog, even if they are acknowledged, until they fall out of the messageRetentionDuration window.
+      retain_acked_messages = optional(bool)
     }))
 
     # threshold for high message alarms for consumer's queue. defaults to 5000.


### PR DESCRIPTION
- max delivery attempts should be customizable
- support for exponential retry policy, [message filtering](https://cloud.google.com/pubsub/docs/subscription-message-filter#filtering_syntax) and acked message retention.

See also: cloudchacho/terraform-google-hedwig-subscription#1