### PR TITLE
Add firehose reloaded; remove dataflow

### DIFF
--- a/topics.tf
+++ b/topics.tf
@@ -3,14 +3,16 @@ module "topics" {
 
   # source  = "cloudchacho/hedwig-topic/google"
   # version = ">= 2.2, <3"
-  # source = "../terraform-google-hedwig-topic"
-  source = "git::https://github.com/max-standard/terraform-google-hedwig-topic.git?ref=firehose-reloaded"
+  source = "../terraform-google-hedwig-topic"
+  # source = "git::https://github.com/max-standard/terraform-google-hedwig-topic.git?ref=firehose-reloaded"
 
   topic = each.key
 
   enable_firehose_all_messages = var.enable_firehose_all_topics || each.value.enable_firehose == true
   firehose_bucket              = each.value.firehose_bucket
   firehose_prefix              = each.value.firehose_prefix
+  firehose_max_duration        = each.value.firehose_max_duration
+  firehose_max_bytes           = each.value.firehose_max_bytes
 
   iam_service_accounts = each.value.service_accounts
   iam_members          = each.value.iam_members

--- a/topics.tf
+++ b/topics.tf
@@ -1,10 +1,8 @@
 module "topics" {
   for_each = var.topics
 
-  # source  = "cloudchacho/hedwig-topic/google"
-  # version = ">= 2.2, <3"
-  source = "/Users/max/terraform-google-hedwig-topic"
-  # source = "git::https://github.com/max-standard/terraform-google-hedwig-topic.git?ref=firehose-reloaded"
+  source  = "cloudchacho/hedwig-topic/google"
+  version = ">= 2.2, <3"
 
   topic                = each.key
   firehose_config      = each.value.firehose_config

--- a/topics.tf
+++ b/topics.tf
@@ -13,6 +13,7 @@ module "topics" {
   firehose_prefix              = each.value.firehose_prefix
   firehose_max_duration        = each.value.firehose_max_duration
   firehose_max_bytes           = each.value.firehose_max_bytes
+  firehose_write_avro          = each.value.firehose_write_avro
 
   iam_service_accounts = each.value.service_accounts
   iam_members          = each.value.iam_members

--- a/topics.tf
+++ b/topics.tf
@@ -1,23 +1,17 @@
 module "topics" {
   for_each = var.topics
 
-  source  = "cloudchacho/hedwig-topic/google"
-  version = ">= 2.2, <3"
+  # source  = "cloudchacho/hedwig-topic/google"
+  # version = ">= 2.2, <3"
+  # source = "../terraform-google-hedwig-topic"
+  source = "git::https://github.com/max-standard/terraform-google-hedwig-topic.git?ref=firehose-reloaded"
 
   topic = each.key
 
   enable_firehose_all_messages = var.enable_firehose_all_topics || each.value.enable_firehose == true
+  firehose_bucket              = each.value.firehose_bucket
+  firehose_prefix              = each.value.firehose_prefix
 
   iam_service_accounts = each.value.service_accounts
   iam_members          = each.value.iam_members
-
-  enable_alerts    = var.enable_alerts
-  alerting_project = var.alerting_project
-
-  dataflow_freshness_alert_notification_channels = var.dataflow_alert_notification_channels
-  dataflow_tmp_gcs_location                      = var.dataflow_tmp_gcs_location
-  dataflow_template_gcs_path                     = var.dataflow_template_pubsub_to_storage_gcs_path
-  dataflow_zone                                  = var.dataflow_zone
-  dataflow_region                                = var.dataflow_region
-  dataflow_output_directory                      = var.dataflow_output_directory
 }

--- a/topics.tf
+++ b/topics.tf
@@ -2,7 +2,7 @@ module "topics" {
   for_each = var.topics
 
   source  = "cloudchacho/hedwig-topic/google"
-  version = ">= 2.2, <3"
+  version = ">= 3.0, <4"
 
   topic                = each.key
   firehose_config      = each.value.firehose_config

--- a/topics.tf
+++ b/topics.tf
@@ -3,7 +3,7 @@ module "topics" {
 
   # source  = "cloudchacho/hedwig-topic/google"
   # version = ">= 2.2, <3"
-  source = "../terraform-google-hedwig-topic"
+  source = "/Users/max/terraform-google-hedwig-topic"
   # source = "git::https://github.com/max-standard/terraform-google-hedwig-topic.git?ref=firehose-reloaded"
 
   topic                = each.key

--- a/topics.tf
+++ b/topics.tf
@@ -6,15 +6,8 @@ module "topics" {
   source = "../terraform-google-hedwig-topic"
   # source = "git::https://github.com/max-standard/terraform-google-hedwig-topic.git?ref=firehose-reloaded"
 
-  topic = each.key
-
-  enable_firehose_all_messages = var.enable_firehose_all_topics || each.value.enable_firehose == true
-  firehose_bucket              = each.value.firehose_bucket
-  firehose_prefix              = each.value.firehose_prefix
-  firehose_max_duration        = each.value.firehose_max_duration
-  firehose_max_bytes           = each.value.firehose_max_bytes
-  firehose_write_avro          = each.value.firehose_write_avro
-
+  topic                = each.key
+  firehose_config      = each.value.firehose_config
   iam_service_accounts = each.value.service_accounts
   iam_members          = each.value.iam_members
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,28 +1,3 @@
-variable "dataflow_tmp_gcs_location" {
-  default     = ""
-  description = "A gs bucket location for storing temporary files by Google Dataflow, e.g. gs://myBucket/tmp"
-}
-
-variable "dataflow_template_pubsub_to_storage_gcs_path" {
-  default     = "gs://dataflow-templates/2019-04-03-00/Cloud_PubSub_to_GCS_Text"
-  description = "The template path for Google Dataflow, e.g. gs://dataflow-templates/2019-04-24-00/Cloud_PubSub_to_GCS_Text"
-}
-
-variable "dataflow_zone" {
-  default     = ""
-  description = "The zone to use for Dataflow. This may be required if it's not set at the provider level, or that zone doesn't support Dataflow regional endpoints (see https://cloud.google.com/dataflow/docs/concepts/regional-endpoints)"
-}
-
-variable "dataflow_region" {
-  default     = ""
-  description = "The region to use for Dataflow. This may be required if it's not set at the provider level, or you want to use a region different from the zone (see https://cloud.google.com/dataflow/docs/concepts/regional-endpoints)"
-}
-
-variable "dataflow_output_directory" {
-  default     = ""
-  description = "A gs bucket location for storing output files by Google Dataflow, e.g. gs://myBucket/hedwigBackup"
-}
-
 variable "enable_firehose_all_topics" {
   default     = false
   description = "Enable firehose for all messages on all topics"
@@ -36,12 +11,6 @@ variable "enable_alerts" {
 variable "alerting_project" {
   default     = ""
   description = "The project id to create monitoring alert policies"
-}
-
-variable "dataflow_alert_notification_channels" {
-  default     = []
-  type        = list(string)
-  description = "List of Stackdriver notification channels for Firehose dataflow data freshness stale alert"
 }
 
 variable "dlq_alert_notification_channels" {
@@ -113,8 +82,14 @@ variable "topics" {
   description = "List of Hedwig topics"
   default     = {}
   type = map(object({
-    # Firehose all messages published to this topic into GCS
+    # Firehose—that is, save—all messages published to this topic into GCS
     enable_firehose = optional(bool)
+
+    # Variable firehose_bucket declares the bucket for firehose—that is, saved—messages (should already exist)
+    firehose_bucket = optional(string)
+
+    # Variable firehose_prefix declares the prefix for firehose—that is, saved—messages. Note: The "<topic>" string is replaced by var.topic; for example, "myenv/<topic>/" variable becomes "myenv/mytopic/" string. This confusing approach enables prefixing all topics in a for-loop.
+    firehose_prefix = optional(string)
 
     # DEPRECATED: use `iam_members` instead
     # service accounts for publishing permissions

--- a/variables.tf
+++ b/variables.tf
@@ -91,7 +91,7 @@ variable "topics" {
 
     # Enable firehose for topic—that is, save all published messages to Cloud Storage
     firehose_config = optional(object({
-      bucket            = optional(string)
+      bucket            = string
       enabled           = optional(bool)
       filename_prefix   = optional(string)
       filename_suffix   = optional(string)

--- a/variables.tf
+++ b/variables.tf
@@ -91,6 +91,12 @@ variable "topics" {
     # Variable firehose_prefix declares the prefix for firehose—that is, saved—messages. Note: The "<topic>" string is replaced by var.topic; for example, "myenv/<topic>/" variable becomes "myenv/mytopic/" string. This confusing approach enables prefixing all topics in a for-loop.
     firehose_prefix = optional(string)
 
+    # The maximum duration that can elapse before a new Cloud Storage file is created. Min 1 minute, max 10 minutes, default 5 minutes. May not exceed the subscription's acknowledgement deadline. A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s"
+    firehose_max_duration = optional(string)
+
+    # The maximum bytes that can be written to a Cloud Storage file before a new file is created. Min 1 KB, max 10 GiB. The maxBytes limit may be exceeded in cases where messages are larger than the limit.
+    firehose_max_bytes = optional(number)
+
     # DEPRECATED: use `iam_members` instead
     # service accounts for publishing permissions
     service_accounts = optional(list(string), [])

--- a/variables.tf
+++ b/variables.tf
@@ -92,7 +92,6 @@ variable "topics" {
     # Enable firehose for topic—that is, save all published messages to Cloud Storage
     firehose_config = optional(object({
       bucket            = string
-      enabled           = optional(bool)
       filename_prefix   = optional(string)
       filename_suffix   = optional(string)
       max_duration      = optional(string)

--- a/variables.tf
+++ b/variables.tf
@@ -82,29 +82,22 @@ variable "topics" {
   description = "List of Hedwig topics"
   default     = {}
   type = map(object({
-    # Firehose—that is, save—all messages published to this topic into GCS
-    enable_firehose = optional(bool)
-
-    # Variable firehose_bucket declares the bucket for firehose—that is, saved—messages (should already exist)
-    firehose_bucket = optional(string)
-
-    # Variable firehose_prefix declares the prefix for firehose—that is, saved—messages. Note: The "<topic>" string is replaced by var.topic; for example, "myenv/<topic>/" variable becomes "myenv/mytopic/" string. This confusing approach enables prefixing all topics in a for-loop.
-    firehose_prefix = optional(string)
-
-    # The maximum duration that can elapse before a new Cloud Storage file is created. Min 1 minute, max 10 minutes, default 5 minutes. May not exceed the subscription's acknowledgement deadline. A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s"
-    firehose_max_duration = optional(string)
-
-    # The maximum bytes that can be written to a Cloud Storage file before a new file is created. Min 1 KB, max 10 GiB. The maxBytes limit may be exceeded in cases where messages are larger than the limit.
-    firehose_max_bytes = optional(number)
-
-    # Write messages to Cloud Storage in Avro format with metadata.
-    firehose_write_avro = optional(bool)
-
     # DEPRECATED: use `iam_members` instead
     # service accounts for publishing permissions
     service_accounts = optional(list(string), [])
 
     # IAM members for publishing permissions
     iam_members = optional(list(string), [])
+
+    # Enable firehose for topic—that is, save all published messages to Cloud Storage
+    firehose_config = optional(object({
+      bucket            = optional(string)
+      enabled           = optional(bool)
+      filename_prefix   = optional(string)
+      filename_suffix   = optional(string)
+      max_duration      = optional(string)
+      max_bytes         = optional(number)
+      write_avro_format = optional(bool)
+    }))
   }))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -97,6 +97,9 @@ variable "topics" {
     # The maximum bytes that can be written to a Cloud Storage file before a new file is created. Min 1 KB, max 10 GiB. The maxBytes limit may be exceeded in cases where messages are larger than the limit.
     firehose_max_bytes = optional(number)
 
+    # Write messages to Cloud Storage in Avro format with metadata.
+    firehose_write_avro = optional(bool)
+
     # DEPRECATED: use `iam_members` instead
     # service accounts for publishing permissions
     service_accounts = optional(list(string), [])


### PR DESCRIPTION
This pull request changes Hedwig firehose facility implementation from Dataflow to Pub/Sub Cloud Storage subscription—see https://cloud.google.com/pubsub/docs/cloudstorage page.

**Done:** After I merge https://github.com/cloudchacho/terraform-google-hedwig-topic/pull/2 pull request, then I should also bump the https://github.com/cloudchacho/terraform-google-hedwig/blob/bae78b0aac0d135aaea1edafe6707fa269aa1f54/topics.tf#L1-L5 version attribute because **Guess:** My https://github.com/cloudchacho/terraform-google-hedwig-topic/pull/2 change should cause a major version bump since I'm removing so many dataflow input variables—see https://github.com/cloudchacho/terraform-google-hedwig/pull/4/commits/9ff62c5f81dd962bc26ac4ceabf28802785bf6d5 commit.